### PR TITLE
Fix in game purchase demo ticket

### DIFF
--- a/src/integration/webpage.ts
+++ b/src/integration/webpage.ts
@@ -323,7 +323,7 @@ export class Game {
             await this.interface.waitForGameEvent('ticketSettled');
             this.connector.onGameSettled();
 
-        } while (!demoGame);
+        } while (true);
 
         this.logger.info('Leaving inGame flow');
         return 'success';


### PR DESCRIPTION
```javascript
                if (event.ticketPriceChanged) {
                    gameScaling.quantity = event.ticketPriceChanged.quantity;
                    gameScaling.betFactor = 1;
                    continue;
                }
```

in demo mode the zig receive `ticketPriceChanged` event run `continue` and goes the `while` loop condition which finished because we are in demo mode. This way we never can't get demo ticket in purchase mode. We must wait normally for `gameFinished` event like in normal buy mode. Tested with one game.