### PR TITLE
Change to 100% height for Safari

### DIFF
--- a/src/integration/fullscreen.ts
+++ b/src/integration/fullscreen.ts
@@ -161,7 +161,7 @@ function styleForOrientation(orientation?: string[]): Style {
         top: '0',
         left: '0',
         width: '100vw',
-        height: '100vh',
+        height: '100%',
         padding: '0',
         margin: '0',
         'z-index': '9999',


### PR DESCRIPTION
In order to have correct `innerHeight` in the `iframe`, it must be styled with height of `height: 100%` rather than `height: 100vh`. 

Ref:
- https://github.com/mui-org/material-ui/issues/12285
- https://github.com/mui-org/material-ui/pull/12528
- https://css-tricks.com/the-trick-to-viewport-units-on-mobile/